### PR TITLE
changed ip addresses to be in line with classful subnet masks

### DIFF
--- a/topics/networking.md
+++ b/topics/networking.md
@@ -165,8 +165,8 @@ python -m SimpleHTTPServer 8080
 
 **Gateway** is the router address we are talking to in order to connect to the rest of the network/internet.
 
-`127.0.0.1` - Your computer.  
-`192.168.x.x` - Local address created by a router.
+`127.x.x.x` - Your computer.  
+`192.168.0.x` - Local address created by a router.
 
 `ifconfig` - Check IP address.  
 `ping 8.8.8.8` - Ping IP address.  


### PR DESCRIPTION
The range of 127.0.0.0-127.255.255.255 is used for loopback. 192.168.0.x is a private class C address meaning the subnet mask is 24 bits, only the last octet can be used for the host ID (provided you're using a classful network).